### PR TITLE
Modify axios to get content in openshift without bypass security

### DIFF
--- a/docker_nodejsb/push_to_elasticsearch.js
+++ b/docker_nodejsb/push_to_elasticsearch.js
@@ -12,9 +12,12 @@ let sites = ['help-wordpress', 'ae', 'internalhr', 'finances'];
 //Read url and write the content of pages in elasticsearch
 const getPages = async (site) => {
     console.log('getPages')
-
+    
+    const agent = new https.Agent({  
+        rejectUnauthorized: false
+       });
     return axios
-        .get(`https://inside.epfl.ch/${site}/wp-json/wp/v2/pages?per_page=100`)
+        .get(`https://httpd-inside:8443/${site}/wp-json/wp/v2/pages?per_page=100`, {httpsAgent: agent, headers:{Host:"inside.epfl.ch"}})
         .then((result) => result)
         .catch((error) => {
             console.error('Erreur get pages ' + error)


### PR DESCRIPTION
We have created a new agent. 
We have changed axios.get to pass the new openshift URL and add two other parameters. One of them is the agent that we have created and the other is the headers host.